### PR TITLE
fix: allow numeric condition values

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ validatePolicySyntax({
   { message: 'Invalid key Comment', path: 'Comment' },
   { message: 'Effect must be present and exactly "Allow" or "Deny"', path: 'Statement[0].Effect' },
   { message: 'Effect must be present and exactly "Allow" or "Deny"', path: 'Statement[1].Effect' },
-  { message: 'Found data type number allowed type(s) are string', path: 'Statement[1].Condition.NumericLessThan s3:max-keys' },
-  { message: 'Found data type object allowed type(s) are string', path: 'Statement[1].Condition.StringLike.s3:authType' }
+  { message: 'Found data type object allowed type(s) are string, boolean, number', path: 'Statement[1].Condition.StringLike.s3:authType' }
 ]
 */
 ```

--- a/src/validate/validate.ts
+++ b/src/validate/validate.ts
@@ -21,7 +21,7 @@ const allowedStatementKeys = new Set([
 const allowedPrincipalKeys = new Set(['AWS', 'Service', 'Federated', 'CanonicalUser'])
 const validConditionOperatorPattern = /^[a-zA-Z0-9:]+$/
 const allowedSetOperators = new Set(['forallvalues', 'foranyvalue'])
-type PolicyDataType = 'string' | 'object' | 'boolean'
+type PolicyDataType = 'string' | 'object' | 'boolean' | 'number'
 
 export interface ValidationCallbacks {
   validateVersion?: (version: any, path: string) => ValidationError[]
@@ -341,7 +341,7 @@ function validateCondition(condition: any, path: string): ValidationError[] {
           ...validateTypeOrArrayOfTypeIfExists(
             condition[operator][key],
             `${path}.${operator}.${key}`,
-            ['string', 'boolean']
+            ['string', 'boolean', 'number']
           )
         )
       }

--- a/src/validate/validateTests/conditions.json
+++ b/src/validate/validateTests/conditions.json
@@ -103,7 +103,7 @@
     "expectedErrors": [
       {
         "path": "Statement.Condition.StringEquals.aws:Username",
-        "message": "Found data type object allowed type(s) are string, boolean"
+        "message": "Found data type object allowed type(s) are string, boolean, number"
       }
     ]
   },
@@ -178,13 +178,13 @@
     "expectedErrors": []
   },
   {
-    "name": "Valid Condition mixed string and boolean array",
+    "name": "Valid Condition mixed string, boolean, and number array",
     "policy": {
       "Statement": {
         "Effect": "Allow",
         "Condition": {
           "Bool": {
-            "aws:MultiFactorAuthPresent": ["true", false]
+            "aws:MultiFactorAuthPresent": ["true", false, 1]
           }
         }
       }
@@ -192,7 +192,7 @@
     "expectedErrors": []
   },
   {
-    "name": "Invalid Condition number value",
+    "name": "Valid Condition number value",
     "policy": {
       "Statement": {
         "Effect": "Allow",
@@ -203,15 +203,10 @@
         }
       }
     },
-    "expectedErrors": [
-      {
-        "path": "Statement.Condition.NumericEquals.s3:max-keys",
-        "message": "Found data type number allowed type(s) are string, boolean"
-      }
-    ]
+    "expectedErrors": []
   },
   {
-    "name": "Invalid Condition number in array",
+    "name": "Valid Condition number array",
     "policy": {
       "Statement": {
         "Effect": "Allow",
@@ -222,16 +217,7 @@
         }
       }
     },
-    "expectedErrors": [
-      {
-        "path": "Statement.Condition.NumericEquals.s3:max-keys[0]",
-        "message": "Found data type number allowed type(s) are string, boolean"
-      },
-      {
-        "path": "Statement.Condition.NumericEquals.s3:max-keys[1]",
-        "message": "Found data type number allowed type(s) are string, boolean"
-      }
-    ]
+    "expectedErrors": []
   },
   {
     "name": "Validate Condition is not null",


### PR DESCRIPTION
## Summary
- Allow numeric IAM condition values in policy syntax validation
- Update condition validation tests for numeric scalar, numeric arrays, and mixed primitive arrays
- Update README validation example/error message

## Tests
- `npx vitest --run src/validate/validate.test.ts --testNamePattern "Condition number|mixed string, boolean, and number|Invalid Values"`
- `npm run build`
- `npm test`
- `npm run format-check`

## Risks / Follow-ups
- This is a permissive validation change. Existing valid policies remain valid; numeric condition values no longer produce syntax errors.